### PR TITLE
Mv/fix us915

### DIFF
--- a/src/lora_plan.erl
+++ b/src/lora_plan.erl
@@ -1210,7 +1210,7 @@ valid_uplink_freq(Plan, Freq) ->
             true;
         _ ->
             Ch = lora_region:f2uch(Region, Freq),
-            _Freq2 = lora_region:uch2f(Region, Ch),
+            %% Freq2 = lora_region:uch2f(Region, Ch),
             % io:format("Freq=~w Ch=~w Freq2=~w ~n", [Freq, Ch, Freq2]),
             (Ch > 0)
     end.


### PR DESCRIPTION
he core issue: there was a typo in the list of DataRates.  Somehow I missed adding the SF7BW500 datarate.  That list determines the up to down datarate on the Downlink RX1 Window.

The added unit tests catch the issue.  The tests call both the legacy API and the new library API and do a direct output comparison.