### PR TITLE
add try catch to lora_plan up_to_down_datarate

### DIFF
--- a/src/lora_plan.erl
+++ b/src/lora_plan.erl
@@ -233,9 +233,9 @@ up_to_down_datarate(Plan, Index, Offset) ->
         % io:format("up_to_down_datarate - DownIndex=~w~n", [DownIndex]),
         DownIndex
     catch
-        _ ->
+        _Class:_Reason:_Stacktrace ->
             lager:error(
-                "lora_plan=up_to_down_datarate bad index value region=~p index=~p offset=~p~n", [
+                "lora_plan=up_to_down_datarate bad index value Region=~p Index=~p Offset=~p~n", [
                     Region, Index, Offset
                 ]
             ),


### PR DESCRIPTION
Temporarily log the problem.

Offset is rarely used.  The default is that up index == down index, so simply return index if there is an error.  This may be sufficient.

The real solution is to properly handle the datarate.  Note that for the v1 library we maintained bug for bug compatibility with the previous lorawan logic.  There exists extended data rate conversions we may wish to implement.

Capture info related to this error:

{{case_clause,15},[{lora_plan,dr_offset_list,2,[{file,"/opt/router/_build/default/lib/erlang_lorawan/src/lora_plan.erl"},{line,237}]},{lora_plan,up_to_down_datarate,3,[{file,"/opt/router/_build/default/lib/erlang_lorawan/src/lora_plan.erl"},{line,230}]},{lora_plan,join1_window,3,[{file,"/opt/router/_build/default/lib/erlang_lorawan/src/lora_plan.erl"},{line,436}]},{router_device_worker,handle_info,2,[{file,"/opt/router/src/device/router_device_worker.erl"},{line,1000}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}
[2022-08-02 06:49:42.686] <0.14172.5738> [error] [lora_plan:dr_offset_list:237] gen_server <0.14172.5738> terminated with reason: no case clause matching 15 in lora_plan:dr_offset_list/2 line 237
[2022-08-02 06:49:42.686] <0.14172.5738> [error] [lora_plan:dr_offset_list:237] CRASH REPORT Process <0.14172.5738> with 1 neighbours crashed with reason: no case clause matching 15 in lora_plan:dr_offset_list/2 line 237