### PR TITLE
update dr_offset tables

### DIFF
--- a/src/lora_plan.erl
+++ b/src/lora_plan.erl
@@ -233,13 +233,16 @@ up_to_down_datarate(Plan, Index, Offset) ->
         % io:format("up_to_down_datarate - DownIndex=~w~n", [DownIndex]),
         DownIndex
     catch
+        % Datarate Index is unknown or RFU
+        % Respond with RX2 default datarate
         _Class:_Reason:_Stacktrace ->
             lager:error(
-                "lora_plan=up_to_down_datarate bad index value Region=~p Index=~p Offset=~p~n", [
+                "lora_plan=up_to_down_datarate unknown datarate index Region=~p Index=~p Offset=~p~n",
+                [
                     Region, Index, Offset
                 ]
             ),
-            Index
+            Plan#channel_plan.rx2_datarate
     end.
 
 dr_offset_list(Region, Index) when Region == 'US915' ->
@@ -249,7 +252,9 @@ dr_offset_list(Region, Index) when Region == 'US915' ->
         1 -> [11, 10, 9, 8];
         2 -> [12, 11, 10, 9];
         3 -> [13, 12, 11, 10];
-        4 -> [13, 13, 12, 11]
+        4 -> [13, 13, 12, 11];
+        5 -> [10, 9, 8, 8];
+        6 -> [11, 10, 9, 8]
     end;
 dr_offset_list(Region, Index) when Region == 'AU915' ->
     case Index of
@@ -259,7 +264,8 @@ dr_offset_list(Region, Index) when Region == 'AU915' ->
         3 -> [11, 10, 9, 8, 8, 8];
         4 -> [12, 11, 10, 9, 8, 8];
         5 -> [13, 12, 11, 10, 9, 8];
-        6 -> [13, 13, 12, 11, 10, 9]
+        6 -> [13, 13, 12, 11, 10, 9];
+        7 -> [9, 8, 8, 8, 8, 8]
     end;
 dr_offset_list(Region, Index) when Region == 'CN470' ->
     case Index of
@@ -269,6 +275,47 @@ dr_offset_list(Region, Index) when Region == 'CN470' ->
         3 -> [3, 2, 1, 0, 0, 0];
         4 -> [4, 3, 2, 1, 0, 0];
         5 -> [5, 4, 3, 2, 1, 0]
+    end;
+dr_offset_list(Region, Index) when Region == 'KR920' ->
+    case Index of
+        0 -> [0, 0, 0, 0, 0, 0];
+        1 -> [1, 0, 0, 0, 0, 0];
+        2 -> [2, 1, 0, 0, 0, 0];
+        3 -> [3, 2, 1, 0, 0, 0];
+        4 -> [4, 3, 2, 1, 0, 0];
+        5 -> [5, 4, 3, 2, 1, 0]
+    end;
+dr_offset_list(Region, Index) when Region == 'EU433' ->
+    case Index of
+        0 -> [0, 0, 0, 0, 0, 0];
+        1 -> [1, 0, 0, 0, 0, 0];
+        2 -> [2, 1, 0, 0, 0, 0];
+        3 -> [3, 2, 1, 0, 0, 0];
+        4 -> [4, 3, 2, 1, 0, 0];
+        5 -> [5, 4, 3, 2, 1, 0];
+        6 -> [6, 5, 4, 3, 2, 1];
+        7 -> [7, 6, 5, 4, 3, 2]
+    end;
+dr_offset_list(Region, Index) when Region == 'EU868' ->
+    case Index of
+        0 -> [0, 0, 0, 0, 0, 0, 1, 2];
+        1 -> [1, 0, 0, 0, 0, 0, 2, 3];
+        2 -> [2, 1, 0, 0, 0, 0, 3, 4];
+        3 -> [3, 2, 1, 0, 0, 0, 4, 5];
+        4 -> [4, 3, 2, 1, 0, 0, 5, 6];
+        5 -> [5, 4, 3, 2, 1, 0, 6, 7];
+        6 -> [6, 5, 4, 3, 2, 1, 7, 7];
+        7 -> [7, 6, 5, 4, 3, 2, 7, 7]
+    end;
+dr_offset_list(Region, Index) when Region == 'IN865' ->
+    case Index of
+        0 -> [0, 0, 0, 0, 0, 0, 1, 2];
+        1 -> [1, 0, 0, 0, 0, 0, 2, 3];
+        2 -> [2, 1, 0, 0, 0, 0, 3, 4];
+        3 -> [3, 2, 1, 0, 0, 0, 4, 5];
+        4 -> [4, 3, 2, 1, 0, 0, 5, 5];
+        5 -> [5, 4, 3, 2, 1, 0, 5, 7];
+        7 -> [7, 6, 5, 4, 3, 2, 7, 7]
     end;
 dr_offset_list(_Region, Index) ->
     case Index of

--- a/src/lora_plan.erl
+++ b/src/lora_plan.erl
@@ -101,6 +101,11 @@ valid_region(Region) ->
 %% DataRate Functions
 %% ------------------------------------------------------------------
 
+% Note - APIs are constructed so that in general datarate index, atom and binary
+% can all be considered synonmyous.  For this reason symbol names are often simplified
+% to just daterate, but the underlying type may be an atom, integer or binary depending
+% on what is most convenient.  The LoRaWAN spec similarly treats the term this way.
+
 -spec datarate_to_atom(#channel_plan{}, data_rate()) -> atom().
 datarate_to_atom(Plan, Index) when is_integer(Index) ->
     List = (Plan#channel_plan.data_rates),

--- a/test/lora_plan_tests.erl
+++ b/test/lora_plan_tests.erl
@@ -367,6 +367,10 @@ exercise_snr(Plan) when Plan#channel_plan.base_region == 'AU915' ->
     [validate_snr(Plan, X) || X <- [0, 1, 2, 3, 4]];
 exercise_snr(Plan) when Plan#channel_plan.base_region == 'CN470' ->
     [validate_snr(Plan, X) || X <- [0, 1, 2, 3, 4, 5]];
+exercise_snr(Plan) when Plan#channel_plan.base_region == 'IN865' ->
+    [validate_snr(Plan, X) || X <- [0, 1, 2, 3, 4, 5]];
+exercise_snr(Plan) when Plan#channel_plan.base_region == 'KR920' ->
+    [validate_snr(Plan, X) || X <- [0, 1, 2, 3, 4, 5]];
 exercise_snr(Plan) ->
     [validate_snr(Plan, X) || X <- [0, 1, 2, 3, 4, 5, 6]].
 


### PR DESCRIPTION
Update datarate table values based on most recent Region spec.

For RFU or Index=15 return default rx2 datarate.  This should handle the following error seen in Prod router logs:

[2022-08-03 16:33:38.703] <0.22383.9> [error] [ca010ceb-a75e-4184-9e94-55f338c935b3] [lora_plan:up_to_down_datarate:{237,13}] lora_plan=up_to_down_datarate bad index value Region='US915' Index=15 Offset=0
