### PR TITLE
update data_rate type signature

### DIFF
--- a/src/lora.hrl
+++ b/src/lora.hrl
@@ -30,7 +30,7 @@
 -type dr_id() :: integer().
 -type dr_atom() :: atom().
 -type power_offset() :: integer().
--type data_rate() :: atom() | binary() | integer().
+-type data_rate() :: atom() | binary() | string() | integer().
 
 -record(channel_plan, {
     %% ID from the Region spec


### PR DESCRIPTION
The code already supports string().  We just need to add it to the data_rate type.

Fixes https://github.com/helium/erlang-lorawan/issues/20